### PR TITLE
Bring back toast removal

### DIFF
--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -37,12 +37,14 @@ public class FreedomChat implements ModInitializer {
             try {
                 config = loader.load();
                 final boolean rewriteChat = config.node("rewrite-chat").getBoolean(true);
+                final boolean claimSecureChatEnforced = config.node("claim-secure-chat-enforced").getBoolean(true);
                 final boolean noChatReports = config.node("send-prevents-chat-reports-to-client").getBoolean(false);
                 loader.save(config);
 
                 handler = new FreedomHandler(
                         this,
                         rewriteChat,
+                        claimSecureChatEnforced,
                         noChatReports
                 );
             } catch (final ConfigurateException e) {

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/PlayerManagerMixin.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/PlayerManagerMixin.java
@@ -14,7 +14,7 @@ import ru.bk.oharass.freedomchat.access.ServerCommonNetworkHandlerAccess;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
-    @Inject(method = "onPlayerConnect", at = @At(value = "TAIL"))
+    @Inject(method = "onPlayerConnect", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;transitionInbound(Lnet/minecraft/network/NetworkState;Lnet/minecraft/network/listener/PacketListener;)V", shift = At.Shift.AFTER))
     public void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, ConnectedClientData clientData, CallbackInfo ci) {
         final ChannelPipeline pipeline = ((ServerCommonNetworkHandlerAccess) player.networkHandler).getConnectionAccess().getChannel().pipeline();
         pipeline.addAfter("packet_handler", "freedom_handler", FreedomChat.getHandler());

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -7,9 +7,6 @@
   "authors": [
     "pop4959"
   ],
-  "contributors": [
-    "whiler-sesame"
-  ],
   "contact": {
     "website": "https://modrinth.com/plugin/freedomchat",
     "homepage": "https://modrinth.com/plugin/freedomchat",

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -7,6 +7,9 @@
   "authors": [
     "pop4959"
   ],
+  "contributors": [
+    "whiler-sesame"
+  ],
   "contact": {
     "website": "https://modrinth.com/plugin/freedomchat",
     "homepage": "https://modrinth.com/plugin/freedomchat",

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -26,6 +26,7 @@ public class FreedomChat extends JavaPlugin implements Listener {
 
         final FreedomHandler handler = new FreedomHandler(
                 config.getBoolean("rewrite-chat", true),
+                config.getBoolean("claim-secure-chat-enforced", true),
                 config.getBoolean("send-prevents-chat-reports-to-client", false)
         );
 

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -2,6 +2,14 @@
 # system messages. This is what makes chat not reportable.
 rewrite-chat: true
 
+# Whether FreedomChat should claim to clients that secure chat is enforced.
+# With this set to true, the "Chat messages can't be verified" toast will not
+# be shown. This is, in default configurations, unrelated to allowing clients
+# not signing their messages join. In modern versions, clients also
+# require a valid access token to be present for the popup to be hidden.
+# That being said, you may still see the toast even if this option is enabled.
+claim-secure-chat-enforced: true
+
 # Whether to report the server as secure (disabling chat reporting) to the
 # NoChatReports client mod. This displays a green icon on the server list
 # screen and if enforce-secure-profiles is disabled the open chat screen

--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -6,7 +6,7 @@ rewrite-chat: true
 # With this set to true, the "Chat messages can't be verified" toast will not
 # be shown. This is, in default configurations, unrelated to allowing clients
 # not signing their messages join. In modern versions, clients also
-# require a valid access token to be present for the popup to be hidden.
+# require a valid access token to be present for the toast to be hidden.
 # That being said, you may still see the toast even if this option is enabled.
 claim-secure-chat-enforced: true
 

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ authors:
   - "sulu"
   - "ocelotpotpie"
   - "pop4959"
+  - "whiler-sesame"
 website: "https://github.com/ocelotpotpie/FreedomChat"
-api-version: "1.20"
+api-version: "1.21"
 folia-supported: true

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -7,7 +7,6 @@ authors:
   - "sulu"
   - "ocelotpotpie"
   - "pop4959"
-  - "whiler-sesame"
 website: "https://github.com/ocelotpotpie/FreedomChat"
 api-version: "1.21"
 folia-supported: true


### PR DESCRIPTION
"Enforced secure chat" is now stored in the Join/Login packet. I've injected into it.
Some notes:
- Now it requires something called "profile keys" on the client, that is. __launchers__ MUST launch clients with "profile keys" provided. Vanilla launcher does that. Others sometimes do, sometimes don't. If they don't, the toast will be shown and there's nothing you can do about it from the server-side, but it won't break stuff.
- Fabric injector has been moved a little bit back from TAIL, because Join packet is sent before TAIL in this method.

Properly fixes #50.