### PR TITLE
Make default value false for preventsChatReports

### DIFF
--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/rewrite/CustomServerMetadata.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/rewrite/CustomServerMetadata.java
@@ -24,7 +24,7 @@ public record CustomServerMetadata(Text description, Optional<ServerMetadata.Pla
                                     .forGetter(CustomServerMetadata::favicon),
                             Codec.BOOL.lenientOptionalFieldOf("enforcesSecureChat", false)
                                     .forGetter(CustomServerMetadata::secureChatEnforced),
-                            Codec.BOOL.lenientOptionalFieldOf("preventsChatReports", true)
+                            Codec.BOOL.lenientOptionalFieldOf("preventsChatReports", false)
                                     .forGetter(CustomServerMetadata::preventsChatReports))
                     .apply(instance, CustomServerMetadata::new));
 

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/rewrite/CustomServerMetadata.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/rewrite/CustomServerMetadata.java
@@ -24,7 +24,7 @@ public record CustomServerMetadata(Component description, Optional<ServerStatus.
                                     .forGetter(CustomServerMetadata::favicon),
                             Codec.BOOL.lenientOptionalFieldOf("enforcesSecureChat", false)
                                     .forGetter(CustomServerMetadata::enforcesSecureChat),
-                            Codec.BOOL.lenientOptionalFieldOf("preventsChatReports", true)
+                            Codec.BOOL.lenientOptionalFieldOf("preventsChatReports", false)
                                     .forGetter(CustomServerMetadata::preventsChatReports))
                     .apply(instance, CustomServerMetadata::new));
 


### PR DESCRIPTION
Codecs are smart and therefore won't send default data. When the default value is set to true and actual value to true, codec assumes that the client has true value by default and won't send it, but will send false value if actual value is false. This changes default value to false, so codec will send only true values.

Fixes #53.