### PR TITLE
Use Mojang mappings on Paper

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -3,15 +3,13 @@ plugins {
     id("xyz.jpenilla.run-paper") version "2.3.0"
 }
 
+paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
+
 dependencies {
     paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")
 }
 
 tasks {
-    assemble {
-        dependsOn(reobfJar)
-    }
-
     runServer {
         minecraftVersion("1.21")
     }


### PR DESCRIPTION
Paper now, since 1.20.6, uses Mojang mappings in runtime.
Remapping takes some time, so why don't just yeet it away.

See:
https://docs.papermc.io/paper/dev/userdev#1205-and-beyond
https://forums.papermc.io/threads/paper-velocity-1-20-6.1152/