### PR TITLE
Update config.yml

### DIFF
--- a/paper/src/main/resources/config.yml
+++ b/paper/src/main/resources/config.yml
@@ -8,7 +8,7 @@ rewrite-chat: true
 # not signing their messages join. In modern versions, clients also
 # require a valid access token to be present for the toast to be hidden.
 # That being said, you may still see the toast even if this option is enabled.
-claim-secure-chat-enforced: true
+claim-secure-chat-enforced: false
 
 # Whether to report the server as secure (disabling chat reporting) to the
 # NoChatReports client mod. This displays a green icon on the server list


### PR DESCRIPTION
This is REQUIRED to be shown to not break the MUG, confirmed my staff in Gamersafe and ip_justice (mojang enforcement employee)
![image](https://github.com/user-attachments/assets/1461946a-397e-48ad-a981-1b7b9f13cc74)
the MUG rule being broken
https://www.minecraft.net/en-us/usage-guidelines#commercial