### PR TITLE
Disallow reobf environments

### DIFF
--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -1,5 +1,6 @@
 package ru.bk.oharass.freedomchat;
 
+import io.papermc.paper.util.MappingEnvironment;
 import net.kyori.adventure.key.Key;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.Listener;
@@ -17,6 +18,12 @@ public class FreedomChat extends JavaPlugin implements Listener {
         if (!Boolean.getBoolean("im.evan.freedomchat.bypassprotocolcheck") && this.getServer().getUnsafe().getProtocolVersion() != 770) {
             getLogger().warning("This version of FreedomChat only supports protocol version 770 (1.21.5). Please use the appropriate version of FreedomChat for your server");
             getLogger().warning("If you know what you are doing, set the im.evan.freedomchat.bypassprotocolcheck system property to true to bypass this check");
+            this.getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+        if (!Boolean.getBoolean("im.evan.freedomchat.bypassmappingscheck") && MappingEnvironment.reobf()) {
+            getLogger().warning("This version of FreedomChat only supports Mojang-mapped servers. Please use the Mojang-mapped server JAR");
+            getLogger().warning("If you know what you are doing, set the im.evan.freedomchat.bypassmappingscheck system property to true to bypass this check");
             this.getServer().getPluginManager().disablePlugin(this);
             return;
         }


### PR DESCRIPTION
A "fix" for #70, #73 and countless others, see #62.

A property switch is available for people using broken JARs. Remapping [check](https://github.com/PaperMC/Paper/blob/04ffca0b6ba65b0c711ffc3ac592c2302a48c0a9/paper-server/src/main/java/io/papermc/paper/util/MappingEnvironment.java#L58) in Paper is versatile, but forks of various levels of brokenness do exist.