### PR TITLE
Avoid kicking players when failing to encode

### DIFF
--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -32,6 +32,7 @@ public class FreedomChat extends JavaPlugin implements Listener {
         final FileConfiguration config = this.getConfig();
 
         final FreedomHandler handler = new FreedomHandler(
+                this,
                 config.getBoolean("rewrite-chat", true),
                 config.getBoolean("claim-secure-chat-enforced", false),
                 config.getBoolean("send-prevents-chat-reports-to-client", false),


### PR DESCRIPTION
Currently, if any of the re-encoded packets fail to encode (it can happen, for instance, with malformed clickevents) the players on the receiving end just get kicked.

Perhaps logging the exception is too much, and quietly discarding it might be the move, but I'll let you decide on that.