### PR TITLE
1.21.7 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ subprojects {
     plugins.apply("java-library")
 
     group = "ru.bk.oharass.freedomchat"
-    version = "1.7.4"
+    version = "1.7.5"
     description = "Liberate your server from the chat-reporting bourgeoisie! Disable chat signing server-side."
 
     tasks {

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("dev.architectury.loom") version "1.10-SNAPSHOT"
-    id("com.gradleup.shadow") version "8.3.6"
+    id("com.gradleup.shadow") version "8.3.7"
 }
 
 val shade: Configuration by configurations.creating
@@ -13,11 +13,11 @@ repositories {
 }
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.6")
-    mappings(group = "net.fabricmc", name = "yarn", version = "1.21.6+build.1", classifier = "v2")
+    minecraft(group = "com.mojang", name = "minecraft", version = "1.21.7")
+    mappings(group = "net.fabricmc", name = "yarn", version = "1.21.7+build.1", classifier = "v2")
     modImplementation(group = "net.fabricmc", name = "fabric-loader", version = "0.16.14")
-    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.127.1+1.21.6")
-    shade(implementation(group = "org.spongepowered", name = "configurate-yaml", version = "4.1.2"))
+    modImplementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.128.1+1.21.7")
+    shade(implementation(group = "org.spongepowered", name = "configurate-yaml", version = "4.2.0"))
 }
 
 tasks {

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -23,8 +23,8 @@ public class FreedomChat implements ModInitializer {
     public void onInitialize() {
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             this.server = server;
-            if (!Boolean.getBoolean("im.evan.freedomchat.bypassprotocolcheck") && SharedConstants.getProtocolVersion() != 771) {
-                logger.warn("This version of FreedomChat only supports protocol version 771 (1.21.6). Please use the appropriate version of FreedomChat for your server");
+            if (!Boolean.getBoolean("im.evan.freedomchat.bypassprotocolcheck") && SharedConstants.getProtocolVersion() != 772) {
+                logger.warn("This version of FreedomChat only supports protocol version 772 (1.21.7). Please use the appropriate version of FreedomChat for your server");
                 logger.warn("If you know what you are doing, set the im.evan.freedomchat.bypassprotocolcheck system property to true to bypass this check");
                 return;
             }

--- a/fabric/src/main/resources/freedomchat.mixins.json
+++ b/fabric/src/main/resources/freedomchat.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "ru.bk.oharass.freedomchat.mixins",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ClientConnectionMixin",
     "PlayerManagerMixin",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 
 dependencies {
-    paperweight.paperDevBundle("1.21.6-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.7-R0.1-SNAPSHOT")
 }
 
 tasks {
     runServer {
-        minecraftVersion("1.21.6")
+        minecraftVersion("1.21.7")
     }
 
     processResources {

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -15,8 +15,8 @@ public class FreedomChat extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
-        if (!Boolean.getBoolean("im.evan.freedomchat.bypassprotocolcheck") && this.getServer().getUnsafe().getProtocolVersion() != 771) {
-            getLogger().warning("This version of FreedomChat only supports protocol version 771 (1.21.6). Please use the appropriate version of FreedomChat for your server");
+        if (!Boolean.getBoolean("im.evan.freedomchat.bypassprotocolcheck") && this.getServer().getUnsafe().getProtocolVersion() != 772) {
+            getLogger().warning("This version of FreedomChat only supports protocol version 772 (1.21.7). Please use the appropriate version of FreedomChat for your server");
             getLogger().warning("If you know what you are doing, set the im.evan.freedomchat.bypassprotocolcheck system property to true to bypass this check");
             this.getServer().getPluginManager().disablePlugin(this);
             return;


### PR DESCRIPTION
No actual code changes required except the `compatibilityLevel` must be java 21 because 1.20.5 and later no longer accept java 17 as lowest JDK version.