### PR TITLE
Migrate dependencies to Gradle Version Catalog libs.versions.toml

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("net.fabricmc.fabric-loom") version "1.16-SNAPSHOT"
-    id("com.gradleup.shadow") version "8.3.9"
+    alias(libs.plugins.gradle.fabric.loom)
+    alias(libs.plugins.gradle.shadow)
 }
 
 val shade: Configuration by configurations.creating
@@ -13,10 +13,11 @@ repositories {
 }
 
 dependencies {
-    minecraft(group = "com.mojang", name = "minecraft", version = "26.1.2")
-    implementation(group = "net.fabricmc", name = "fabric-loader", version = "0.19.2")
-    implementation(group = "net.fabricmc.fabric-api", name = "fabric-api", version = "0.147.0+26.1.2")
-    shade(implementation(group = "org.spongepowered", name = "configurate-yaml", version = "4.2.0"))
+    minecraft(libs.minecraft.fabric.mojang)
+    implementation(libs.minecraft.fabric.loader)
+    implementation(libs.minecraft.fabric.api)
+    implementation(libs.configurate.yaml)
+    shade(libs.configurate.yaml)
 }
 
 tasks {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[versions]
+configurate = "4.2.0"
+gradle-fabric-loom = "1.16-SNAPSHOT"
+gradle-paperweight = "2.0.0-beta.21"
+gradle-run-paper = "3.0.2"
+gradle-shadow = "8.3.9"
+minecraft-fabric-api = "0.147.0+26.1.2"
+minecraft-fabric-loader = "0.19.2"
+minecraft-mojang-version = "26.1.2"
+minecraft-paperweight-bundle = "26.1.2.build.+"
+
+[libraries]
+configurate-yaml = { module = "org.spongepowered:configurate-yaml", version.ref = "configurate" }
+minecraft-fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "minecraft-fabric-api" }
+minecraft-fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "minecraft-fabric-loader" }
+minecraft-fabric-mojang = { module = "com.mojang:minecraft", version.ref = "minecraft-mojang-version" }
+
+[plugins]
+gradle-fabric-loom = { id = "net.fabricmc.fabric-loom", version.ref = "gradle-fabric-loom" }
+gradle-paperweight-userdev = { id = "io.papermc.paperweight.userdev", version.ref = "gradle-paperweight" }
+gradle-run-paper = { id = "xyz.jpenilla.run-paper", version.ref = "gradle-run-paper" }
+gradle-shadow = { id = "com.gradleup.shadow", version.ref = "gradle-shadow" }

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -1,17 +1,17 @@
 plugins {
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
-    id("xyz.jpenilla.run-paper") version "3.0.2"
+    alias(libs.plugins.gradle.paperweight.userdev)
+    alias(libs.plugins.gradle.run.paper)
 }
 
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 
 dependencies {
-    paperweight.paperDevBundle("26.1.2.build.+")
+    paperweight.paperDevBundle(libs.versions.minecraft.paperweight.bundle.get())
 }
 
 tasks {
     runServer {
-        minecraftVersion("26.1.2")
+        minecraftVersion(libs.versions.minecraft.mojang.version.get())
     }
 
     processResources {


### PR DESCRIPTION
Centralizes all plugin and dependency versions into a single `TOML` file with type-safe accessors, making upgrades a one-line change instead of hunting through every `build.gradle.kts`