### PR TITLE
fix(all): pending message queue fix (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.gradle
 **/build
 paper/run
+fabric/run

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomHandler.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/FreedomHandler.java
@@ -32,6 +32,7 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
     private final boolean claimSecureChatEnforced;
     private final boolean noChatReports;
     private final boolean bedrockOnly;
+    private final PendingChatAcks pendingChatAcks;
 
     public FreedomHandler(final FreedomChat freedom, final boolean rewriteChat, final boolean claimSecureChatEnforced, final boolean noChatReports, final boolean bedrockOnly) {
         final RegistryAccess registryAccess = freedom.getServer().registryAccess();
@@ -41,6 +42,7 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
         this.claimSecureChatEnforced = claimSecureChatEnforced;
         this.noChatReports = noChatReports;
         this.bedrockOnly = bedrockOnly;
+        this.pendingChatAcks = new PendingChatAcks();
     }
 
     @Override
@@ -72,6 +74,7 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
         final ClientboundSystemChatPacket system = new ClientboundSystemChatPacket(decoratedContent, false);
 
         s2cPlayPacketCodec.encode(buf, system);
+        pendingChatAcks.forget(ctx.channel(), msg.signature());
     }
 
     private void encode(@SuppressWarnings("unused") final ChannelHandlerContext ctx, final ClientboundLoginPacket msg, final FriendlyByteBuf buf) {

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/PendingChatAcks.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/PendingChatAcks.java
@@ -1,0 +1,47 @@
+package ru.bk.oharass.freedomchat;
+
+import io.netty.channel.Channel;
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import net.minecraft.network.Connection;
+import net.minecraft.network.PacketListener;
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.network.chat.LastSeenTrackedEntry;
+import net.minecraft.network.chat.MessageSignature;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.jetbrains.annotations.Nullable;
+import ru.bk.oharass.freedomchat.mixins.LastSeenMessagesValidatorAccess;
+import ru.bk.oharass.freedomchat.mixins.ServerGamePacketListenerImplAccess;
+
+final class PendingChatAcks {
+    private static final String PACKET_HANDLER = "packet_handler";
+
+    PendingChatAcks() {
+    }
+
+    void forget(final Channel channel, final @Nullable MessageSignature signature) {
+        if (signature == null) {
+            return;
+        }
+
+        if (!(channel.pipeline().get(PACKET_HANDLER) instanceof Connection connection)) {
+            return;
+        }
+
+        final PacketListener packetListener = connection.getPacketListener();
+        if (!(packetListener instanceof ServerGamePacketListenerImpl listener)) {
+            return;
+        }
+
+        final LastSeenMessagesValidator validator = ((ServerGamePacketListenerImplAccess) listener).freedomChat$getLastSeenMessages();
+        synchronized (validator) {
+            final ObjectList<LastSeenTrackedEntry> trackedMessages = ((LastSeenMessagesValidatorAccess) validator).freedomChat$getTrackedMessages();
+            for (int i = trackedMessages.size() - 1; i >= 0; i--) {
+                final LastSeenTrackedEntry entry = trackedMessages.get(i);
+                if (entry != null && entry.pending() && signature.equals(entry.signature())) {
+                    trackedMessages.remove(i);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/LastSeenMessagesValidatorAccess.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/LastSeenMessagesValidatorAccess.java
@@ -1,0 +1,13 @@
+package ru.bk.oharass.freedomchat.mixins;
+
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.network.chat.LastSeenTrackedEntry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(LastSeenMessagesValidator.class)
+public interface LastSeenMessagesValidatorAccess {
+    @Accessor("trackedMessages")
+    ObjectList<LastSeenTrackedEntry> freedomChat$getTrackedMessages();
+}

--- a/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/ServerGamePacketListenerImplAccess.java
+++ b/fabric/src/main/java/ru/bk/oharass/freedomchat/mixins/ServerGamePacketListenerImplAccess.java
@@ -1,0 +1,12 @@
+package ru.bk.oharass.freedomchat.mixins;
+
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerGamePacketListenerImpl.class)
+public interface ServerGamePacketListenerImplAccess {
+    @Accessor("lastSeenMessages")
+    LastSeenMessagesValidator freedomChat$getLastSeenMessages();
+}

--- a/fabric/src/main/resources/freedomchat.mixins.json
+++ b/fabric/src/main/resources/freedomchat.mixins.json
@@ -5,8 +5,10 @@
   "compatibilityLevel": "JAVA_25",
   "mixins": [
     "ClientConnectionMixin",
+    "LastSeenMessagesValidatorAccess",
     "PlayerManagerMixin",
-    "ServerCommonNetworkHandlerMixin"
+    "ServerCommonNetworkHandlerMixin",
+    "ServerGamePacketListenerImplAccess"
   ],
   "client": [
   ],

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomChat.java
@@ -25,6 +25,7 @@ public class FreedomChat extends JavaPlugin implements Listener {
         final FileConfiguration config = this.getConfig();
 
         final FreedomHandler handler = new FreedomHandler(
+                getLogger(),
                 config.getBoolean("rewrite-chat", true),
                 config.getBoolean("claim-secure-chat-enforced", false),
                 config.getBoolean("send-prevents-chat-reports-to-client", false),

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomHandler.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/FreedomHandler.java
@@ -24,6 +24,7 @@ import ru.bk.oharass.freedomchat.rewrite.CustomServerMetadata;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.logging.Logger;
 
 @ChannelHandler.Sharable
 public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
@@ -33,8 +34,9 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
     private final boolean claimSecureChatEnforced;
     private final boolean noChatReports;
     private final boolean bedrockOnly;
+    private final PendingChatAcks pendingChatAcks;
 
-    public FreedomHandler(final boolean rewriteChat, final boolean claimSecureChatEnforced, final boolean noChatReports, final boolean bedrockOnly) {
+    public FreedomHandler(final Logger logger, final boolean rewriteChat, final boolean claimSecureChatEnforced, final boolean noChatReports, final boolean bedrockOnly) {
         final RegistryAccess registryAccess = MinecraftServer.getServer().registryAccess();
         final Function<ByteBuf, RegistryFriendlyByteBuf> bufRegistryAccess = RegistryFriendlyByteBuf.decorator(registryAccess);
         this.s2cPlayPacketCodec = GameProtocols.CLIENTBOUND_TEMPLATE.bind(bufRegistryAccess).codec();
@@ -42,6 +44,7 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
         this.claimSecureChatEnforced = claimSecureChatEnforced;
         this.noChatReports = noChatReports;
         this.bedrockOnly = bedrockOnly;
+        this.pendingChatAcks = new PendingChatAcks(logger);
     }
 
     @Override
@@ -73,6 +76,7 @@ public class FreedomHandler extends MessageToByteEncoder<Packet<?>> {
         final ClientboundSystemChatPacket system = new ClientboundSystemChatPacket(decoratedContent, false);
 
         s2cPlayPacketCodec.encode(buf, system);
+        pendingChatAcks.forget(ctx.channel(), msg.signature());
     }
 
     private void encode(@SuppressWarnings("unused") final ChannelHandlerContext ctx, final ClientboundLoginPacket msg, final FriendlyByteBuf buf) {

--- a/paper/src/main/java/ru/bk/oharass/freedomchat/PendingChatAcks.java
+++ b/paper/src/main/java/ru/bk/oharass/freedomchat/PendingChatAcks.java
@@ -1,0 +1,92 @@
+package ru.bk.oharass.freedomchat;
+
+import io.netty.channel.Channel;
+import it.unimi.dsi.fastutil.objects.ObjectList;
+import net.minecraft.network.Connection;
+import net.minecraft.network.PacketListener;
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.network.chat.LastSeenTrackedEntry;
+import net.minecraft.network.chat.MessageSignature;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class PendingChatAcks {
+    private static final String PACKET_HANDLER = "packet_handler";
+
+    private final Logger logger;
+    private final @Nullable VarHandle lastSeenMessages;
+    private final @Nullable VarHandle trackedMessages;
+
+    private boolean warned;
+
+    PendingChatAcks(final Logger logger) {
+        this.logger = logger;
+        VarHandle lastSeenMessages = null;
+        VarHandle trackedMessages = null;
+        try {
+            final MethodHandles.Lookup lookup = MethodHandles.lookup();
+            final MethodHandles.Lookup serverGamePacketListenerLookup = MethodHandles.privateLookupIn(ServerGamePacketListenerImpl.class, lookup);
+            final MethodHandles.Lookup lastSeenMessagesValidatorLookup = MethodHandles.privateLookupIn(LastSeenMessagesValidator.class, lookup);
+            lastSeenMessages = serverGamePacketListenerLookup.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "lastSeenMessages",
+                    LastSeenMessagesValidator.class
+            );
+            trackedMessages = lastSeenMessagesValidatorLookup.findVarHandle(
+                    LastSeenMessagesValidator.class,
+                    "trackedMessages",
+                    ObjectList.class
+            );
+        } catch (ReflectiveOperationException | RuntimeException ex) {
+            warnOnce(ex);
+        }
+        this.lastSeenMessages = lastSeenMessages;
+        this.trackedMessages = trackedMessages;
+    }
+
+    void forget(final Channel channel, final @Nullable MessageSignature signature) {
+        if (signature == null || lastSeenMessages == null || trackedMessages == null) {
+            return;
+        }
+
+        try {
+            if (!(channel.pipeline().get(PACKET_HANDLER) instanceof Connection connection)) {
+                return;
+            }
+
+            final PacketListener packetListener = connection.getPacketListener();
+            if (!(packetListener instanceof ServerGamePacketListenerImpl listener)) {
+                return;
+            }
+
+            final LastSeenMessagesValidator validator = (LastSeenMessagesValidator) lastSeenMessages.get(listener);
+            synchronized (validator) {
+                @SuppressWarnings("unchecked")
+                final ObjectList<LastSeenTrackedEntry> trackedMessages = (ObjectList<LastSeenTrackedEntry>) this.trackedMessages.get(validator);
+                for (int i = trackedMessages.size() - 1; i >= 0; i--) {
+                    final LastSeenTrackedEntry entry = trackedMessages.get(i);
+                    if (entry != null && entry.pending() && signature.equals(entry.signature())) {
+                        trackedMessages.remove(i);
+                        break;
+                    }
+                }
+            }
+        } catch (RuntimeException ex) {
+            warnOnce(ex);
+        }
+    }
+
+    private void warnOnce(final Exception ex) {
+        if (!warned) {
+            warned = true;
+            logger.log(Level.WARNING,
+                    "FreedomChat could not access Paper's pending chat acknowledgement state; " +
+                    "rewritten chat may still count as unacknowledged", ex);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes issue #103, where message signatures are added to the pending acknowledgement queue before the packet is sent. Given these messages are sent as system chat, the client never acknowledges them, eventually causing the queue to fill after more than 4096 messages and causing the kick.

While at it, I changed the handler to use disguised chat packets instead of system chat one. This works better with the narrator system, since we no longer flatten the chat type ourselves, from my testing I haven't found any drawbacks to this.

Platform-specific notes:

Paper:
The signature is still added to the pending acknowledgement queue, so we have to reflectively remove it after insertion.

Fabric:
The mixin can hook earlier and send the disguised chat packet directly, avoiding insertion into the pending acknowledgement queue entirely.

This PR is more disruptive than I initially intended, mostly on the Fabric side, and also because of the disguised chat packet change. I am marking it as a draft for now.

Please let me know whether this PR should only contain the pending ack queue fix, or whether the disguised chat packet change and Fabric mixin changes should stay here, be split into separate PRs, or be dropped.